### PR TITLE
Update to latest npm in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,9 @@ jobs:
         node-version: ${{ matrix.node }}
         cache: npm
     - name: Install latest npm
-      run: npm install --global npm@latest
+      run: |
+        npm install --global npm@latest
+        npm -v
     - name: Install dependencies
       run: npm ci
     - name: Cache turbo
@@ -48,7 +50,9 @@ jobs:
         node-version: 20
         cache: npm
     - name: Install latest npm
-      run: npm install --global npm@latest
+      run: |
+        npm install --global npm@latest
+        npm -v
     - name: Install dependencies
       run: npm ci
     - name: Cache turbo
@@ -196,7 +200,9 @@ jobs:
         cache: npm
         registry-url: 'https://registry.npmjs.org'
     - name: Install latest npm
-      run: npm install --global npm@latest
+      run: |
+        npm install --global npm@latest
+        npm -v
     - name: Install dependencies
       run: npm ci
     - name: Run Publish

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,8 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
         cache: npm
+    - name: Install latest npm
+      run: npm install --global npm@latest
     - name: Install dependencies
       run: npm ci
     - name: Cache turbo
@@ -45,6 +47,8 @@ jobs:
       with:
         node-version: 20
         cache: npm
+    - name: Install latest npm
+      run: npm install --global npm@latest
     - name: Install dependencies
       run: npm ci
     - name: Cache turbo
@@ -188,9 +192,11 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 20
         cache: npm
         registry-url: 'https://registry.npmjs.org'
+    - name: Install latest npm
+      run: npm install --global npm@latest
     - name: Install dependencies
       run: npm ci
     - name: Run Publish


### PR DESCRIPTION
9.6.7 contains a fix so that workspace scripts with node 20 correctly report errors in the exit code again