### PR TITLE
Add new accounts scopes

### DIFF
--- a/apps/example/app/token/page.tsx
+++ b/apps/example/app/token/page.tsx
@@ -35,8 +35,8 @@ export default async function TokenPage({ searchParams }: { searchParams: { acce
   const access_token = searchParams.access_token;
 
   const api = gw2me.api(access_token);
-  const user = await api.user();
-  const accounts = await api.accounts().catch(() => {});
+  const user = await api.user().catch((e) => String(e));
+  const accounts = await api.accounts().catch((e) => String(e));
 
   return (
     <form>
@@ -50,12 +50,15 @@ export default async function TokenPage({ searchParams }: { searchParams: { acce
       <FlexRow>
         <Button icon="revision" type="submit" formAction={refreshTokenAction}>Refresh Token</Button>
       </FlexRow>
+      <br/>
 
+      <b>/api/user</b>
       <pre>{JSON.stringify(user, undefined, '  ')}</pre>
+      <b>/api/accounts</b>
       <pre>{JSON.stringify(accounts, undefined, '  ')}</pre>
 
       <FlexRow>
-        {accounts?.accounts?.map((account) => (
+        {typeof accounts === 'object' && accounts?.accounts?.map((account) => (
           <Button key={account.id} icon="key" type="submit" formAction={getSubtoken.bind(null, account.id)}>Get Subtoken ({account.name})</Button>
         ))}
       </FlexRow>

--- a/apps/web/app/(user)/profile/page.tsx
+++ b/apps/web/app/(user)/profile/page.tsx
@@ -31,7 +31,7 @@ export default async function ProfilePage() {
 
   return (
     <PageLayout>
-      <Headline id="profile" actions={<LinkButton href="/logout" external>Logout</LinkButton>}>
+      <Headline id="profile" actions={<LinkButton href="/logout" icon="logout" external>Logout</LinkButton>}>
         {user.name}
       </Headline>
 

--- a/apps/web/app/dev/docs/access-tokens/page.tsx
+++ b/apps/web/app/dev/docs/access-tokens/page.tsx
@@ -87,7 +87,7 @@ export default function DevDocsAccessTokensPage() {
           <tr>
             <td><Code inline>verified_accounts_only</Code> (optional)</td>
             <td><Code inline borderless>&quot;true&quot;</Code></td>
-            <td>Only allow the user to select verified accounts.</td>
+            <td>Only allow the user to select verified accounts. This requires the <Link href="/dev/docs/scopes"><Code inline>accounts.verified</Code> scope</Link>.</td>
           </tr>
         </tbody>
       </Table>
@@ -105,7 +105,7 @@ export default function DevDocsAccessTokensPage() {
       <p>If the authorization was successful, the url will contain the query parameter <Code inline>code</Code> with an authorization code that needs to be exchanged for an access token in the next step.</p>
       <Code>https://example.com/callback<br/>  ?state=ocbBQyUo1G6551bD5sNMdA<br/>  &<strong>code=ciA-F7NVbINw1dcEVeYdww</strong></Code>
 
-      <p>If the authoriztion was not successful, the url will contain the <Code inline>error</Code> and <Code inline>error_description</Code> query parameters detailing the reason.</p>
+      <p>If the authorization was not successful, the url will contain the <Code inline>error</Code> and <Code inline>error_description</Code> query parameters detailing the reason.</p>
       <Code>https://example.com/callback<br/>  ?state=yuUK87DIP1NSCfL8XdHM2A<br/>  &<strong>error=access_denied</strong><br/>  &<strong>error_description=user+canceled+authorization</strong></Code>
 
 
@@ -165,7 +165,7 @@ export default function DevDocsAccessTokensPage() {
           'token_type': 'Bearer',
           'expires_in': 604800,
           'refresh_token': 'mcn6FMwoiufzqcBDVwzOnz_NvGn-1ezzRKIm7vN_bsk',
-          'scope': 'identify email gw2:account'
+          'scope': 'identify accounts gw2:account'
         }, null, 2)}
       </Code>
 

--- a/apps/web/app/dev/docs/gw2-api/page.tsx
+++ b/apps/web/app/dev/docs/gw2-api/page.tsx
@@ -28,7 +28,7 @@ export default function DevDocsGW2APIPage() {
         Before you can request a subtoken, you will need to get the list of accounts
         the user has shared with your application. Make a request to <Code inline>https://gw2.me/api/accounts</Code>.
         You will need to pass your <Code inline>access_token</Code> as a header (<Code inline>Authorization: Bearer &lt;access_token&gt;</Code>).
-        This requires at least one <Link href="/dev/docs/scopes">Guild Wars 2 scope</Link>.
+        This requires the <Link href="/dev/docs/scopes"><Code inline>accounts</Code> scope</Link>.
       </p>
 
       <p>
@@ -41,6 +41,13 @@ export default function DevDocsGW2APIPage() {
           accounts: [{ id: 'C2BFF77D-B669-E111-809D-78E7D1936EF0', name: 'darthmaim.6017' }]
         }, null, 2)}
       </Code>
+
+      <p>
+        If the scopes include <Code inline>accounts.displayName</Code>, each account object will include
+        the <Code inline>displayName</Code> the user has set (or <Code inline>null</Code>, if the user has not set a custom display name).
+        Similarly, if the scope <Code inline>accounts.verified</Code> is included, the response will contain
+        the boolean <Code inline>verified</Code> with the ownership verification status of each account.
+      </p>
 
       <Headline id="subtoken">Request Subtoken</Headline>
 

--- a/apps/web/app/dev/docs/scopes/page.tsx
+++ b/apps/web/app/dev/docs/scopes/page.tsx
@@ -28,6 +28,18 @@ export default function DevDocsScopePage() {
             <td><Code inline>email</Code></td>
             <td>Include the email in /api/user</td>
           </tr>
+          <tr>
+            <td><Code inline>accounts</Code></td>
+            <td>Get the list of accounts from /api/accounts. This scope is always implied when any <Code inline>gw2:*</Code> scope is included.</td>
+          </tr>
+          <tr>
+            <td><Code inline>accounts.displayName</Code></td>
+            <td>Include the user-defined displa name in the account list</td>
+          </tr>
+          <tr>
+            <td><Code inline>accounts.verified</Code></td>
+            <td>Include the account verification status.</td>
+          </tr>
 
           <tr>
             <td><Code inline>gw2:account</Code></td>

--- a/apps/web/app/dev/layout.tsx
+++ b/apps/web/app/dev/layout.tsx
@@ -20,7 +20,7 @@ export default function DevLayout({ children }: { children: ReactNode }) {
       ]}/>
       <Separator/>
       <Navigation prefix="/dev/" items={[
-        { segment: 'applications', label: 'Your Applications' },
+        { segment: 'applications', icon: 'apps', label: 'Your Applications' },
       ]}/>
     </NavLayout>
   );

--- a/apps/web/app/oauth2/authorize/actions.ts
+++ b/apps/web/app/oauth2/authorize/actions.ts
@@ -42,7 +42,7 @@ export async function authorizeInternal(
   accountIds: string[]
 ) {
   // verify at least one account was selected
-  if(hasGW2Scopes(scopes) && accountIds.length === 0) {
+  if((hasGW2Scopes(scopes) || scopes.includes(Scope.Accounts)) && accountIds.length === 0) {
     return { error: 'At least one account has to be selected.' };
   }
 

--- a/apps/web/app/oauth2/authorize/page.module.css
+++ b/apps/web/app/oauth2/authorize/page.module.css
@@ -5,12 +5,13 @@
 }
 
 .scopeList > li {
-  padding: 8px 16px;
+  padding: 6px 16px;
   border: 1px solid var(--color-border);
   border-radius: 2px;
   display: grid;
   gap: 12px;
   grid-template-columns: 16px auto;
+  line-height: 1.5;
 }
 
 .scopeList > li + li {
@@ -18,7 +19,7 @@
 }
 
 .scopeList > li > svg {
-  margin-top: 2px;
+  margin-top: 4px;
 }
 
 .accountSection {

--- a/packages/client/src/api.ts
+++ b/packages/client/src/api.ts
@@ -13,7 +13,8 @@ export interface AccountsResponse {
   accounts: {
     id: string;
     name: string;
-    verified: boolean;
+    verified?: boolean;
+    displayName?: string | null;
   }[]
 }
 

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -2,6 +2,10 @@ export enum Scope {
   Identify = 'identify',
   Email = 'email',
 
+  Accounts = 'accounts',
+  Accounts_Verified = 'accounts.verified',
+  Accounts_DisplayName = 'accounts.displayName',
+
   GW2_Account = 'gw2:account',
   GW2_Inventories = 'gw2:inventories',
   GW2_Characters = 'gw2:characters',


### PR DESCRIPTION
This PR adds 3 new scopes

- `accounts` - List of accounts. This is allows applications to get the account names without the ability to generate subtokens. For backwards compatibility this scope is always set if any `gw2:*` scope is set.
- `accounts.verified` - Include the ownership verification status for each account in the `/api/accounts` response.
- `accounts.displayName` - Include the custom user-set display name for each account in the `/api/accounts` response