### PR TITLE
Remove overrides for `eslint-config-next`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,5 @@
     "eslint-formatter-gha": "1.5.1",
     "turbo": "2.1.2"
   },
-  "overrides": {
-    "eslint-config-next": {
-      "@typescript-eslint/eslint-plugin": "8.5.0",
-      "@typescript-eslint/parser": "8.5.0"
-    }
-  },
   "packageManager": "npm@10.8.3"
 }


### PR DESCRIPTION
Not required anymore, since Next.js 14.2.12 (#1040) now supports typescript-eslint v8