### PR TITLE
Ignore `docker-compose.database-migration.yml` in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,9 @@
   "kubernetes": {
     "fileMatch": ["kubernetes/.+\\.yaml$"]
   },
+  "ignorePaths": [
+    "docker-compose.database-migration.yml"
+  ],
   "packageRules": [
     {
       "matchSourceUrls": "https://github.com/GW2Treasures/gw2treasures.com",


### PR DESCRIPTION
The `docker-compose.database-migration.yml` refers to the previous postgres version on purpose, renovate should not upgrade this.