### PR TITLE
Remove `revalidatePath` from login route

### DIFF
--- a/apps/web/app/login/page.tsx
+++ b/apps/web/app/login/page.tsx
@@ -4,7 +4,6 @@ import { Headline } from '@gw2treasures/ui/components/Headline/Headline';
 import { Notice } from '@gw2treasures/ui/components/Notice/Notice';
 import { PageLayout } from '@/components/Layout/PageLayout';
 import { LoginForm } from './form';
-import { revalidatePath } from 'next/cache';
 import { cookies } from 'next/headers';
 
 export const dynamic = 'force-dynamic';
@@ -13,7 +12,6 @@ export default async function LoginPage() {
   const session = await getSession();
 
   if(session) {
-    revalidatePath('/profile');
     redirect('/profile');
   }
 


### PR DESCRIPTION
This would throw this error:
```raw
 ⨯ Error: Route /login used "revalidatePath /profile" during render which is unsupported. To ensure revalidation is performed consistently it must always happen outside of renders and cached functions. See more info here: https://nextjs.org/docs/app/building-your-application/rendering/static-and-dynamic#dynamic-rendering
    at LoginPage (./app/login/page.tsx:31:67)
```