### PR TITLE
Remove redirect from `switchUser` action

### DIFF
--- a/apps/web/app/login/form.tsx
+++ b/apps/web/app/login/form.tsx
@@ -20,7 +20,6 @@ import { revalidatePath } from 'next/cache';
 import { LoginErrorCookieName, UserCookieName } from '@/lib/cookie';
 import { PasskeyAuthenticationButton } from '@/components/Passkey/PasskeyAuthenticationButton';
 import { NoticeContext } from '@/components/NoticeContext/NoticeContext';
-import { redirect } from 'next/navigation';
 
 interface LoginFormProps {
   returnTo?: string;
@@ -110,15 +109,13 @@ export async function getPreviousUser() {
   return user ?? undefined;
 }
 
-// eslint-disable-next-line require-await
 async function switchUser() {
   'use server';
 
   const cookieStore = await cookies();
   cookieStore.delete(UserCookieName);
 
-  revalidatePath('/login');
-  redirect('/login');
+  revalidatePath('');
 }
 
 export const enum LoginError {


### PR DESCRIPTION
If the login form was shown on the consent screen and a user would click "Not you?", the user would get redirected to the login page instead of staying on the auth screen.