### PR TITLE
Extract `assertRequestAuthentication` into own file

### DIFF
--- a/apps/web/app/api/(oauth)/auth.test.ts
+++ b/apps/web/app/api/(oauth)/auth.test.ts
@@ -1,0 +1,66 @@
+/** @jest-environment node */
+import { OAuth2ErrorCode } from '@/lib/oauth/error';
+import { assertRequestAuthentication } from './auth';
+import { dbMock } from '@/lib/db.mock';
+import { Client, ClientSecret, ClientType } from '@gw2me/database';
+import { describe, expect, it } from '@jest/globals';
+import { generateClientSecretAndHash } from '@/lib/token';
+
+const client: Client & { secrets: ClientSecret[] } = {
+  id: 'test',
+  applicationId: 'app-id',
+  callbackUrls: [],
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  type: 'Public',
+  secrets: [],
+};
+
+const headers = new Headers();
+
+describe('authentication', () => {
+  beforeEach(() => {
+    dbMock.client.findUnique.mockResolvedValue(client);
+  });
+
+  describe('public client', () => {
+    it('works', () =>
+      expect(() => assertRequestAuthentication(client, headers, {})).not.toThrow());
+    it('throws if authorization header was provided', () =>
+      expect(() => assertRequestAuthentication(client, new Headers({ 'Authorization': 'Basic foo' }), {}))
+        .toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Do not pass authorization for public clients.'));
+    it('throws if client secret was provided', () =>
+      expect(() => assertRequestAuthentication(client, headers, { client_secret: '' }))
+        .toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Do not pass authorization for public clients.'));
+  });
+
+  describe('confidential client', () => {
+    let secret: Awaited<ReturnType<typeof generateClientSecretAndHash>>;
+    let confidentialClient: typeof client;
+
+    beforeAll(async () => {
+      secret = await generateClientSecretAndHash();
+      confidentialClient = { ...client, type: ClientType.Confidential, secrets: [{ secret: secret.hashed } as ClientSecret] };
+    });
+
+    it('throws if no authentication was provided', () =>
+      expect(() => assertRequestAuthentication(confidentialClient, headers, {}))
+        .toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Missing authorization for confidential client'));
+
+    it('throws if non basic auth header was provided', () =>
+      expect(() => assertRequestAuthentication(confidentialClient, new Headers({ 'Authorization': 'Bearer foo' }), {}))
+        .toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Only "Basic" authorization is supported using the Authorization header'));
+
+    it('throws if malformed basic auth header was provided', () =>
+      expect(() => assertRequestAuthentication(confidentialClient, new Headers({ 'Authorization': 'Basic !"§$' }), {}))
+        .toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Unexpected client_id in Authorization header'));
+
+    it('supports client_secret_basic', () =>
+      expect(() => assertRequestAuthentication(confidentialClient, new Headers({ 'Authorization': `Basic ${btoa(`${client.id}:${secret.raw}`)}` }), {}))
+        .not.toThrow());
+
+    it('supports client_secret_post', () =>
+      expect(() => assertRequestAuthentication(confidentialClient, headers, { client_secret: secret.raw }))
+        .not.toThrow());
+  });
+});

--- a/apps/web/app/api/(oauth)/auth.ts
+++ b/apps/web/app/api/(oauth)/auth.ts
@@ -1,0 +1,84 @@
+import 'server-only';
+import { db } from '@/lib/db';
+import { assert } from '@/lib/oauth/assert';
+import { OAuth2ErrorCode } from '@/lib/oauth/error';
+import { AuthenticationMethod } from '@/lib/oauth/types';
+import { ClientType, ClientSecret, Client } from '@gw2me/database';
+import { scryptSync, timingSafeEqual } from 'crypto';
+import { unstable_after as after } from 'next/server';
+
+export function assertRequestAuthentication(
+  client: Client & { secrets: ClientSecret[] },
+  headers: Headers,
+  params: Record<string, string | undefined>
+): void {
+  const authHeader = headers.get('Authorization');
+
+  const authorizationMethods: Record<AuthenticationMethod, boolean> = {
+    client_secret_basic: !!authHeader,
+    client_secret_post: params.client_secret !== undefined,
+  };
+
+  const usedAuthentication = Object.entries(authorizationMethods)
+    .filter(([, used]) => used)
+    .map(([key]) => key as AuthenticationMethod);
+
+  // no authentication provided
+  if(usedAuthentication.length === 0) {
+    assert(client.type === ClientType.Public, OAuth2ErrorCode.invalid_request, 'Missing authorization for confidential client');
+    return;
+  }
+
+  // if authentication was provided, this needs to be a confidential client
+  assert(client.type === ClientType.Confidential, OAuth2ErrorCode.invalid_request, 'Do not pass authorization for public clients.');
+
+  // only allow 1 authorization method
+  assert(usedAuthentication.length === 1, OAuth2ErrorCode.invalid_request, 'Only used one authorization method');
+
+  const [method] = usedAuthentication;
+
+  switch(method) {
+    case 'client_secret_basic':
+    case 'client_secret_post': {
+      let client_secret: string | undefined;
+
+      if(method === 'client_secret_basic') {
+        const [basic, encoded] = authHeader!.split(' ', 2);
+        assert(basic === 'Basic', OAuth2ErrorCode.invalid_request, 'Only "Basic" authorization is supported using the Authorization header');
+
+        const [id, password] = Buffer.from(encoded, 'base64').toString().split(':', 2);
+        assert(id === client.id, OAuth2ErrorCode.invalid_request, 'Unexpected client_id in Authorization header');
+
+        client_secret = password;
+      } else {
+        client_secret = params.client_secret;
+      }
+
+      assert(client_secret, OAuth2ErrorCode.invalid_request, 'Missing client_secret');
+
+      const clientSecret = client.secrets.find(({ secret }) => isValidClientSecret(client_secret, secret));
+      assert(clientSecret, OAuth2ErrorCode.invalid_client, 'Invalid client_secret');
+
+      // set `usedAt` of secret
+      after(() => db.clientSecret.update({
+        where: { id: clientSecret.id },
+        data: { usedAt: new Date() }
+      }));
+    }
+  }
+}
+
+function isValidClientSecret(clientSecret: string, saltedHash: string | null): boolean {
+  if(saltedHash === null) {
+    return false;
+  }
+
+  const [salt, hash] = saltedHash.split(':');
+
+  const saltBuffer = Buffer.from(salt, 'base64');
+  const hashBuffer = Buffer.from(hash, 'base64');
+  const secretBuffer = Buffer.from(clientSecret, 'base64url');
+
+  const derived = scryptSync(secretBuffer, saltBuffer, 32);
+  return timingSafeEqual(hashBuffer, derived);
+}

--- a/apps/web/app/api/(oauth)/token/token.test.ts
+++ b/apps/web/app/api/(oauth)/token/token.test.ts
@@ -1,12 +1,11 @@
 /** @jest-environment node */
 import { OAuth2ErrorCode } from '@/lib/oauth/error';
-import { assertPKCECodeChallenge, assertRequestAuthentication, handleTokenRequest } from './token';
+import { assertPKCECodeChallenge, handleTokenRequest } from './token';
 import { dbMock } from '@/lib/db.mock';
-import { Account, Authorization, Client, ClientSecret, ClientType } from '@gw2me/database';
+import { Account, Authorization, Client } from '@gw2me/database';
 import { expiresAt } from '@/lib/date';
 import { Scope } from '@gw2me/client';
 import { describe, expect, it } from '@jest/globals';
-import { generateClientSecretAndHash } from '@/lib/token';
 
 type MockAuthorization = Authorization & { accounts: Pick<Account, 'id'>[] };
 
@@ -27,14 +26,13 @@ const mockAuthorization: MockAuthorization = {
   accounts: [],
 };
 
-const client: Client & { secrets: ClientSecret[] } = {
+const client: Client = {
   id: 'test',
   applicationId: 'app-id',
   callbackUrls: [],
   createdAt: new Date(),
   updatedAt: new Date(),
   type: 'Public',
-  secrets: [],
 };
 
 const headers = new Headers();
@@ -103,29 +101,5 @@ describe('/api/token', () => {
     it('unknown method', () => expect(() => assertPKCECodeChallenge('foo:challenge', 'bar')).toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Unsupported code challenge'));
     it('wrong verifier', () => expect(() => assertPKCECodeChallenge('S256:challenge', 'wrong')).toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'code challenge verification failed'));
     it('success', () => expect(() => assertPKCECodeChallenge('S256:w6uP8Tcg6K2QR905Rms8iXTlksL6OD1KOWBxTK7wxPI', 'foobar')).not.toThrow());
-  });
-
-  describe('authentication', () => {
-    describe('public client', () => {
-      it('works', () => expect(() => assertRequestAuthentication(client, headers, {})).not.toThrow());
-      it('throws if authorization header was provided', () => expect(() => assertRequestAuthentication(client, new Headers({ 'Authorization': 'Basic foo' }), {})).toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Do not pass authorization for public clients.'));
-      it('throws if client secret was provided', () => expect(() => assertRequestAuthentication(client, headers, { client_secret: '' })).toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Do not pass authorization for public clients.'));
-    });
-
-    describe('confidential client', () => {
-      let secret: Awaited<ReturnType<typeof generateClientSecretAndHash>>;
-      let confidentialClient: typeof client;
-
-      beforeAll(async () => {
-        secret = await generateClientSecretAndHash();
-        confidentialClient = { ...client, type: ClientType.Confidential, secrets: [{ secret: secret.hashed } as ClientSecret] };
-      });
-
-      it('throws if no authentication was provided', () => expect(() => assertRequestAuthentication(confidentialClient, headers, {})).toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Missing authorization for confidential client'));
-      it('handles non basic auth header', () => expect(() => assertRequestAuthentication(confidentialClient, new Headers({ 'Authorization': 'Bearer foo' }), {})).toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Only "Basic" authorization is supported using the Authorization header'));
-      it('handles malformed basic auth header', () => expect(() => assertRequestAuthentication(confidentialClient, new Headers({ 'Authorization': 'Basic !"§$' }), {})).toThrowOAuth2Error(OAuth2ErrorCode.invalid_request, 'Unexpected client_id in Authorization header'));
-      it('supports client_secret_basic', () => expect(() => assertRequestAuthentication(confidentialClient, new Headers({ 'Authorization': `Basic ${btoa(`${client.id}:${secret.raw}`)}` }), {})).not.toThrow());
-      it('supports client_secret_post', () => expect(() => assertRequestAuthentication(confidentialClient, headers, { client_secret: secret.raw })).not.toThrow());
-    });
   });
 });

--- a/apps/web/app/api/(oauth)/token/token.ts
+++ b/apps/web/app/api/(oauth)/token/token.ts
@@ -2,12 +2,11 @@ import { expiresAt, isExpired } from '@/lib/date';
 import { db } from '@/lib/db';
 import { assert } from '@/lib/oauth/assert';
 import { OAuth2Error, OAuth2ErrorCode } from '@/lib/oauth/error';
-import { AuthenticationMethod } from '@/lib/oauth/types';
 import { generateAccessToken, generateRefreshToken } from '@/lib/token';
 import { TokenResponse } from '@gw2me/client';
-import { ClientType, AuthorizationType, ClientSecret, Client } from '@gw2me/database';
-import { createHash, scryptSync, timingSafeEqual } from 'crypto';
-import { unstable_after as after } from 'next/server';
+import { ClientType, AuthorizationType } from '@gw2me/database';
+import { createHash } from 'crypto';
+import { assertRequestAuthentication } from '../auth';
 
 // 7 days
 const ACCESS_TOKEN_EXPIRATION = 604800;
@@ -142,82 +141,6 @@ export async function handleTokenRequest(headers: Headers, params: Record<string
 
 function isValidGrantType(grant_type: string | undefined): grant_type is 'authorization_code' | 'refresh_token' {
   return grant_type === 'authorization_code' || grant_type === 'refresh_token';
-}
-
-function isValidClientSecret(clientSecret: string, saltedHash: string | null): boolean {
-  if(saltedHash === null) {
-    return false;
-  }
-
-  const [salt, hash] = saltedHash.split(':');
-
-  const saltBuffer = Buffer.from(salt, 'base64');
-  const hashBuffer = Buffer.from(hash, 'base64');
-  const secretBuffer = Buffer.from(clientSecret, 'base64url');
-
-  const derived = scryptSync(secretBuffer, saltBuffer, 32);
-  return timingSafeEqual(hashBuffer, derived);
-}
-
-export function assertRequestAuthentication(
-  client: Client & { secrets: ClientSecret[] },
-  headers: Headers,
-  params: Record<string, string | undefined>
-): void {
-  const authHeader = headers.get('Authorization');
-
-  const authorizationMethods: Record<AuthenticationMethod, boolean> = {
-    client_secret_basic: !!authHeader,
-    client_secret_post: params.client_secret !== undefined,
-  };
-
-  const usedAuthentication = Object.entries(authorizationMethods)
-    .filter(([, used]) => used)
-    .map(([key]) => key as AuthenticationMethod);
-
-  // no authentication provided
-  if(usedAuthentication.length === 0) {
-    assert(client.type === ClientType.Public, OAuth2ErrorCode.invalid_request, 'Missing authorization for confidential client');
-    return;
-  }
-
-  // if authentication was provided, this needs to be a confidential client
-  assert(client.type === ClientType.Confidential, OAuth2ErrorCode.invalid_request, 'Do not pass authorization for public clients.');
-
-  // only allow 1 authorization method
-  assert(usedAuthentication.length === 1, OAuth2ErrorCode.invalid_request, 'Only used one authorization method');
-
-  const [method] = usedAuthentication;
-
-  switch(method) {
-    case 'client_secret_basic':
-    case 'client_secret_post': {
-      let client_secret: string | undefined;
-
-      if(method === 'client_secret_basic') {
-        const [basic, encoded] = authHeader!.split(' ', 2);
-        assert(basic === 'Basic', OAuth2ErrorCode.invalid_request, 'Only "Basic" authorization is supported using the Authorization header');
-
-        const [id, password] = Buffer.from(encoded, 'base64').toString().split(':', 2);
-        assert(id === client.id, OAuth2ErrorCode.invalid_request, 'Unexpected client_id in Authorization header');
-
-        client_secret = password;
-      } else {
-        client_secret = params.client_secret;
-      }
-
-      assert(client_secret, OAuth2ErrorCode.invalid_request, 'Missing client_secret');
-
-      const clientSecret = client.secrets.find(({ secret }) => isValidClientSecret(client_secret, secret));
-      assert(clientSecret, OAuth2ErrorCode.invalid_client, 'Invalid client_secret');
-
-      // set `usedAt` of secret
-      after(() => db.clientSecret.update({
-        where: { id: clientSecret.id },
-        data: { usedAt: new Date() }
-      }));
-    }
-  }
 }
 
 // instead of returning false if some check fails, throw OAuth2Error with description why code challenge failed


### PR DESCRIPTION
No functional changes, only moved `assertRequestAuthentication` and related tests into their own files.