### PR TITLE
Add Issuer Identification (RFC 9207)

### DIFF
--- a/apps/web/app/.well-known/oauth-authorization-server/route.ts
+++ b/apps/web/app/.well-known/oauth-authorization-server/route.ts
@@ -16,7 +16,8 @@ export function GET(request: NextRequest) {
     grant_types_supported: ['authorization_code', 'refresh_token'],
     token_endpoint_auth_methods_supported: Object.values(AuthenticationMethod),
     service_documentation: new URL('/dev/docs', currentUrl),
-    code_challenge_methods_supported: ['S256']
+    code_challenge_methods_supported: ['S256'],
+    authorization_response_iss_parameter_supported: true,
   };
 
   return NextResponse.json(metadata);

--- a/apps/web/app/dev/docs/access-tokens/page.tsx
+++ b/apps/web/app/dev/docs/access-tokens/page.tsx
@@ -104,11 +104,16 @@ export default function DevDocsAccessTokensPage() {
       <p>After the user authorized your application, the user is redirected to the specified <Code inline>redirect_uri</Code>.</p>
 
       <p>If the authorization was successful, the url will contain the query parameter <Code inline>code</Code> with an authorization code that needs to be exchanged for an access token in the next step.</p>
-      <Code>https://example.com/callback<br/>  ?state=SaOfpb7Ny9mbV6EPCUDcnQ<br/>  &<strong>code=ciA-F7NVbINw1dcEVeYdww</strong></Code>
+      <Code>https://example.com/callback<br/>  ?state=SaOfpb7Ny9mbV6EPCUDcnQ<br/>  &iss=https%3A%2F%2Fgw2.me<br/>  &<strong>code=ciA-F7NVbINw1dcEVeYdww</strong></Code>
 
       <p>If the authorization was not successful, the url will contain the <Code inline>error</Code> and <Code inline>error_description</Code> query parameters detailing the reason.</p>
-      <Code>https://example.com/callback<br/>  ?state=SaOfpb7Ny9mbV6EPCUDcnQ<br/>  &<strong>error=access_denied</strong><br/>  &<strong>error_description=user+canceled+authorization</strong></Code>
+      <Code>https://example.com/callback<br/>  ?state=SaOfpb7Ny9mbV6EPCUDcnQ<br/>  &iss=https%3A%2F%2Fgw2.me<br/>  &<strong>error=access_denied</strong><br/>  &<strong>error_description=user+canceled+authorization</strong></Code>
 
+      <p>
+        The url for both the success and error response will always contain <Code inline>iss</Code> and
+        (if passed to the authorization request) <Code inline>state</Code>, both of which should be verified.
+        See <Link href="#issuer-identification">Issuer Identification</Link> for more details on the <Code inline>iss</Code> parameter.
+      </p>
 
       <Headline id="access-token">Access Token</Headline>
 
@@ -157,6 +162,14 @@ export default function DevDocsAccessTokensPage() {
           </tr>
         </tbody>
       </Table>
+
+      <p>
+        Confidential applications have to authenticate themselves using their client secret.
+        The client secret can either be passed using &quot;Basic&quot; HTTP Authentication (also called <Code inline>client_secret_basic</Code> in the context of OAuth2),
+        using the <Code inline>client_id</Code> as username and the <Code inline>client_secret</Code> as password,
+        or by using <Code inline>client_secret_post</Code> auth, passing the <Code inline>client_secret</Code> as
+        body parameter as part of the token response.
+      </p>
 
       <p>If the request is successful, the response will contain the access token used to access any other API endpoints.</p>
 
@@ -220,6 +233,17 @@ export default function DevDocsAccessTokensPage() {
           Only if it matches the server responds with an access token.
         </div>
       </Steps>
+
+      <Headline id="issuer-identification">Issuer Identification</Headline>
+
+      <p>
+        The authorization response contains the <Code inline>iss</Code> parameter.
+        This parameter is part of <ExternalLink href="https://datatracker.ietf.org/doc/html/rfc9207">RFC 9207 - OAuth 2.0 Authorization Server Issuer Identification</ExternalLink> and
+        contains the issuer identifier, which is always <Code inline>https://gw2.me</Code> for gw2.me.
+      </p>
+      <p>
+        All clients should verify that this parameter exactly matches to prevent mix-up attacks.
+      </p>
     </PageLayout>
   );
 }

--- a/apps/web/app/oauth2/authorize/actions.ts
+++ b/apps/web/app/oauth2/authorize/actions.ts
@@ -99,7 +99,7 @@ export async function authorizeInternal(
   }
 
   // build redirect url with token and state
-  const url = createRedirectUrl(redirect_uri, {
+  const url = await createRedirectUrl(redirect_uri, {
     state,
     code: authorization.token,
   });

--- a/apps/web/app/oauth2/authorize/page.tsx
+++ b/apps/web/app/oauth2/authorize/page.tsx
@@ -89,7 +89,7 @@ export default async function AuthorizePage({ searchParams: asyncSearchParams }:
 
   // handle prompt=none
   if(!allPreviouslyAuthorized && request.prompt === 'none') {
-    const errorUrl = createRedirectUrl(redirect_uri, {
+    const errorUrl = await createRedirectUrl(redirect_uri, {
       state: request.state,
       error: OAuth2ErrorCode.access_denied,
       error_description: 'user not previously authorized',
@@ -117,7 +117,7 @@ export default async function AuthorizePage({ searchParams: asyncSearchParams }:
     : [];
 
   // build cancel url
-  const cancelUrl = createRedirectUrl(redirect_uri, {
+  const cancelUrl = await createRedirectUrl(redirect_uri, {
     state: request.state,
     error: OAuth2ErrorCode.access_denied,
     error_description: 'user canceled authorization',

--- a/apps/web/app/oauth2/authorize/validate.ts
+++ b/apps/web/app/oauth2/authorize/validate.ts
@@ -144,7 +144,7 @@ export const validateRequest = cache(async function validateRequest(request: Par
     let redirect_uri: URL;
 
     if(error instanceof OAuth2Error) {
-      redirect_uri = createRedirectUrl(request.redirect_uri!, {
+      redirect_uri = await createRedirectUrl(request.redirect_uri!, {
         state: request.state,
         error: error.code,
         error_description: error.description
@@ -152,7 +152,7 @@ export const validateRequest = cache(async function validateRequest(request: Par
     } else {
       console.log(error);
 
-      redirect_uri = createRedirectUrl(request.redirect_uri!, {
+      redirect_uri = await createRedirectUrl(request.redirect_uri!, {
         state: request.state,
         error: OAuth2ErrorCode.server_error,
         error_description: 'internal server error'

--- a/apps/web/lib/redirectUrl.ts
+++ b/apps/web/lib/redirectUrl.ts
@@ -1,5 +1,6 @@
 import { isDefined } from '@gw2treasures/helper/is';
 import { OAuth2ErrorCode } from './oauth/error';
+import { getBaseUrlFromHeaders } from './url';
 
 type RedirectUrlSearchParamsCommon = {
   /** An opaque value used by the client to maintain state between the request and callback. */
@@ -34,8 +35,12 @@ type RedirectUrlSearchParams =
  * @param searchParams The additional searchParams to append to the url
  * @returns The modified url
  */
-export function createRedirectUrl(base: string | URL, searchParams: RedirectUrlSearchParams): URL {
+export async function createRedirectUrl(base: string | URL, searchParams: RedirectUrlSearchParams): Promise<URL> {
   const url = new URL(base);
+
+  // always include issuer
+  const { origin: issuer } = await getBaseUrlFromHeaders();
+  url.searchParams.set('iss', issuer);
 
   Object.entries(searchParams)
     .filter(([, value]) => isDefined(value))


### PR DESCRIPTION
[RFC 9207 - OAuth 2.0 Authorization Server Issuer Identification](https://datatracker.ietf.org/doc/html/rfc9207)

This adds the `iss` parameter when redirecting back to the client and `authorization_response_iss_parameter_supported` to the auth server metadata.