### PR TITLE
Add issuer verification to @gw2me/client

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gw2me/client",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "gw2.me client library",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/client/src/error.ts
+++ b/packages/client/src/error.ts
@@ -1,0 +1,15 @@
+export class Gw2MeError extends Error {}
+
+export class Gw2MeOAuthError extends Gw2MeError {
+  constructor(
+    public error: string,
+    public error_description?: string,
+    public error_uri?: string
+  ) {
+    super(
+      `Received ${error}` +
+      (error_description ? `: ${error_description}` : '') +
+      (error_uri ? ` (${error_uri})` : '')
+    );
+  }
+}

--- a/packages/client/src/fed-cm.ts
+++ b/packages/client/src/fed-cm.ts
@@ -1,3 +1,5 @@
+import { Gw2MeError } from "./error";
+
 export interface FedCMRequestOptions {
   mediation?: CredentialMediationRequirement;
   mode?: 'button';
@@ -19,7 +21,7 @@ export class Gw2MeFedCM {
 
   request({ mediation, signal, mode }: FedCMRequestOptions) {
     if(!this.isSupported()) {
-      throw new Error('FedCM is not supported');
+      throw new Gw2MeError('FedCM is not supported');
     }
 
     return navigator.credentials.get({

--- a/packages/client/src/index.ts
+++ b/packages/client/src/index.ts
@@ -1,3 +1,4 @@
 export * from './types';
 export * from './client';
 export * from './api';
+export * from './error';

--- a/packages/client/src/util.ts
+++ b/packages/client/src/util.ts
@@ -1,3 +1,5 @@
+import { Gw2MeError } from './error';
+
 export async function jsonOrError(response: Response) {
   const isJson = response.headers.get('Content-Type') === 'application/json';
 
@@ -11,11 +13,11 @@ export async function jsonOrError(response: Response) {
       errorMessage = error.error_description;
     }
 
-    throw new Error(`gw2.me returned an error: ${errorMessage ?? 'Unknown error'}`);
+    throw new Gw2MeError(`gw2.me returned an error: ${errorMessage ?? 'Unknown error'}`);
   }
 
   if(!isJson) {
-    throw new Error('gw2.me did not return a valid JSON response');
+    throw new Gw2MeError('gw2.me did not return a valid JSON response');
   }
 
   return response.json();


### PR DESCRIPTION
gw2.me now supports the issuer identifier (see #1197). This adds a new function to the client library to parse the returned search params, which also verifies the issuer identifier.

TODO:
- [x] in case of an error response instead of throwing a generic `Error`, this should throw a custom error which allows access to `error`, `error_description` and `error_uri`