### PR TITLE
Increase web deployment CPU limit

### DIFF
--- a/kubernetes/base/web/deployment.yaml
+++ b/kubernetes/base/web/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             cpu: "10m"
           limits:
             memory: "256Mi"
-            cpu: "50m"
+            cpu: "150m"
         env:
         - name: DATABASE_URL
           valueFrom:


### PR DESCRIPTION
During startup the app was being throttled and sometimes failed status probes.
