### PR TITLE
Parse content-type header

### DIFF
--- a/apps/web/lib/oauth/assert.ts
+++ b/apps/web/lib/oauth/assert.ts
@@ -23,7 +23,12 @@ export function fail(condition: unknown, code: OAuth2ErrorCode, description?: st
 export function tryOrFail<T>(callback: () => T, code: OAuth2ErrorCode, description?: string): T {
   try {
     return callback();
-  } catch {
+  } catch(e) {
+    // rethrow inner OAuth2 errors
+    if(e instanceof OAuth2Error) {
+      throw e;
+    }
+
     throw new OAuth2Error(code, { description });
   }
 }


### PR DESCRIPTION
The Content-Type assertion was just doing plain string comparison (expecting `application/x-www-form-urlencoded`). This is wrong, as the Content-Type header can include additional parameters (for example `application/x-www-form-urlencoded;charset=UTF-8`).

This now parses the header correctly and only compares the essence.

Fixes #1547