### PR TITLE
Temporary increase subtoken expiration

### DIFF
--- a/apps/web/app/api/(authorized)/accounts/[id]/subtoken/route.ts
+++ b/apps/web/app/api/(authorized)/accounts/[id]/subtoken/route.ts
@@ -81,8 +81,9 @@ export const OPTIONS = OptionsHandler;
 
 async function createSubtoken(apiToken: { id: string, token: string }, requiredPermissions: string[]): Promise<SubtokenResponse> {
   // create expiration time in 10 minutes
+  // TODO: temporarily increased to 1h while the official GW2 API is experiencing issues
   const expire = new Date();
-  expire.setMinutes(expire.getMinutes() + 10);
+  expire.setMinutes(expire.getMinutes() + 60);
 
   // create subtoken
   let apiResponse;


### PR DESCRIPTION
This temporarily increases the subtoken expiration time from 10 minutes to 60 minutes, so in the rare case the API manages to not timeout, the user actually gets to use the token for some time... 