### PR TITLE
Update `eslint-plugin-react-hooks` to 7.1.1

### DIFF
--- a/apps/web/components/Format/FormatDate.tsx
+++ b/apps/web/components/Format/FormatDate.tsx
@@ -1,18 +1,16 @@
 'use client';
 
+import { useHydrated } from '@/lib/use-hydrated';
 import { Tip } from '@gw2treasures/ui/components/Tip/Tip';
-import { FC, useEffect, useState } from 'react';
+import { FC } from 'react';
 
 interface FormatDateProps {
   date: Date,
 }
 
 export const FormatDate: FC<FormatDateProps> = ({ date }) => {
-  const [value, setValue] = useState(date.toUTCString());
-
-  useEffect(() => {
-    setValue(date.toLocaleString());
-  }, [date]);
+  const hydrated = useHydrated();
+  const value = hydrated ? date.toLocaleString() : date.toUTCString();
 
   return (
     <Tip tip={date.toUTCString()}>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2627,11 +2627,11 @@ packages:
       '@typescript-eslint/parser':
         optional: true
 
-  eslint-plugin-react-hooks@7.0.1:
-    resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
+  eslint-plugin-react-hooks@7.1.1:
+    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
     engines: {node: '>=18'}
     peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
+      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -5140,7 +5140,7 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.6.1))
-      eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.6.1))
       typescript-eslint: 8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
@@ -7015,7 +7015,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.6.1)):
+  eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/parser': 7.29.2


### PR DESCRIPTION
Co-authored-by: Copilot <copilot@github.com>
